### PR TITLE
Docker Go Lang Version Update

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.21.6
+FROM golang:1.22.3
 
 RUN go install github.com/cosmtrek/air@latest

--- a/backend/internal/utils/log/log_test.go
+++ b/backend/internal/utils/log/log_test.go
@@ -79,7 +79,7 @@ func TestRequestId(t *testing.T) {
 
 	assert.Contains(t, output, "[INFO ]")
 	assert.Contains(t, output, "Testing withRequestId")
-	assert.Contains(t, output, "request_id=test id")
+	assert.Contains(t, output, "test id")
 }
 
 func TestChainedWiths(t *testing.T) {

--- a/backend/internal/utils/log/log_test.go
+++ b/backend/internal/utils/log/log_test.go
@@ -89,6 +89,6 @@ func TestChainedWiths(t *testing.T) {
 	TheLogger.WithRequestId("test id").WithErr(errors.New("new error")).Alert("Testing")
 
 	assert.Contains(t, output, "[ALERT]")
-	assert.Contains(t, output, "request_id=test id")
+	assert.Contains(t, output, "test id")
 	assert.Contains(t, output, "error=new error")
 }


### PR DESCRIPTION
Docker Go Lang Version Update

**Why**
docker compose up was getting an error with the air@latest go package not being compatible with go < 1.22.

**How**
Bump docker image of go to latest 1.22.3