### PR TITLE
Updated more golang version references and removed docker compose version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21.6'
+        go-version: '1.22.3'
         cache-dependency-path: backend/go.sum
 
     - name: Build

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/jak103/powerplay
 
-go 1.21.3
+go 1.22.3
 
 require (
 	github.com/caarlos0/env/v10 v10.0.0

--- a/build/Dockerfile.production
+++ b/build/Dockerfile.production
@@ -6,7 +6,7 @@
 # ENV NODE_ENV production
 # RUN npm run build
 
-FROM golang:1.21.6 AS backend
+FROM golang:1.22.3 AS backend
 WORKDIR /app
 COPY ./backend .
 RUN CGO_ENABLED=0 go build -o powerplay ./main.go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   frontend:
     image: frontend:latest


### PR DESCRIPTION
- Updated golang version references from `1.21.*` to `1.22.3`
- Removed docker compose version as it's [outdated](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements)