### PR TITLE
Initial Seed Script

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jak103/powerplay/internal/config"
 	"github.com/jak103/powerplay/internal/db/migrations"
 
+	ppseeders "github.com/jak103/powerplay/internal/db/seeders"
 	"github.com/jak103/powerplay/internal/utils/locals"
 	"github.com/jak103/powerplay/internal/utils/log"
 	"gorm.io/driver/postgres"
@@ -83,6 +84,15 @@ func GetSession(c *fiber.Ctx) session {
 		}),
 	}
 	return s
+}
+
+func RunSeeders(seeders []ppseeders.Seeder) error {
+	for _, seeder := range seeders {
+		if err := seeder.Seed(db); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resultOrError[T any](t *T, result *gorm.DB) (*T, error) {

--- a/backend/internal/db/migrations/migrate.go
+++ b/backend/internal/db/migrations/migrate.go
@@ -10,6 +10,7 @@ import (
 var migrations []*gormigrate.Migration
 
 func init() {
+	// todo: break into migration files #59 - https://github.com/jak103/powerplay/issues/59
 	migrations = append(migrations,
 		&gormigrate.Migration{
 			ID: "create_penalty_type_table",
@@ -18,6 +19,26 @@ func init() {
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return tx.Migrator().DropTable("penalty_types")
+			},
+		},
+		&gormigrate.Migration{
+			ID: "penalty_type_remove_player_column",
+			Migrate: func(tx *gorm.DB) error {
+				if tx.Migrator().HasColumn(&models.PenaltyType{}, "PlayerID") {
+					if err := tx.Migrator().DropColumn(&models.PenaltyType{}, "PlayerID"); err != nil {
+						log.WithErr(err).Alert("Error dropping column 'PlayerID' on PenaltyType")
+						return err
+					}
+				}
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				if !tx.Migrator().HasColumn(&models.PenaltyType{}, "player_id") {
+					if err := tx.Migrator().AddColumn(&models.PenaltyType{}, "player_id"); err != nil {
+						return err
+					}
+				}
+				return nil
 			},
 		},
 		// Add more migrations here

--- a/backend/internal/db/seeders/penalty_type.go
+++ b/backend/internal/db/seeders/penalty_type.go
@@ -1,0 +1,32 @@
+package seeders
+
+import (
+	"github.com/jak103/powerplay/internal/models"
+	"gorm.io/gorm"
+)
+
+type PenaltyTypeSeeder struct{}
+
+func (pt PenaltyTypeSeeder) Seed(db *gorm.DB) error {
+	penaltyTypes := []models.PenaltyType{
+		{Name: "Tripping", Duration: 2, Severity: "minor"},
+		{Name: "Hooking", Duration: 2, Severity: "minor"},
+		{Name: "Slashing", Duration: 2, Severity: "minor"},
+		{Name: "Interference", Duration: 2, Severity: "minor"},
+		{Name: "Holding", Duration: 2, Severity: "minor"},
+		{Name: "High-sticking", Duration: 2, Severity: "minor"},
+		{Name: "Fighting", Duration: 5, Severity: "major"},
+		{Name: "Charging", Duration: 5, Severity: "major"},
+		{Name: "Boarding", Duration: 5, Severity: "major"},
+		{Name: "Cross-checking", Duration: 5, Severity: "major"},
+		{Name: "Unsportsmanlike Conduct", Duration: 10, Severity: "misconduct"},
+		{Name: "Game misconduct", Duration: 0, Severity: "game_misconduct"},
+		{Name: "Match Penalty", Duration: 0, Severity: "match"},
+	}
+	for _, penaltyType := range penaltyTypes {
+		if err := db.FirstOrCreate(&penaltyType, models.PenaltyType{Name: penaltyType.Name, Duration: penaltyType.Duration, Severity: penaltyType.Severity}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/internal/db/seeders/seeder.go
+++ b/backend/internal/db/seeders/seeder.go
@@ -1,0 +1,7 @@
+package seeders
+
+import "gorm.io/gorm"
+
+type Seeder interface {
+	Seed(db *gorm.DB) error
+}

--- a/backend/internal/models/penalty.go
+++ b/backend/internal/models/penalty.go
@@ -5,8 +5,6 @@ import "time"
 type PenaltyType struct {
 	DbModel
 	Name     string        `json:"name"`
-	PlayerID uint          `json:"player_id"`
-	Player   User          `json:"player"`
 	Duration time.Duration `json:"duration"`
 	Severity string        `json:"severity"`
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"github.com/jak103/powerplay/internal/config"
 	"github.com/jak103/powerplay/internal/db"
+	ppseeders "github.com/jak103/powerplay/internal/db/seeders"
 	"github.com/jak103/powerplay/internal/server"
 	"github.com/jak103/powerplay/internal/utils/log"
 )
@@ -15,6 +16,19 @@ func runMigrations() {
 		return
 	}
 	log.Info("Migrations completed successfully")
+}
+
+func runSeeds() {
+	seeders := []ppseeders.Seeder{
+		ppseeders.PenaltyTypeSeeder{},
+		// Add more seeders here
+	}
+
+	// Seed the database
+	if err := db.RunSeeders(seeders); err != nil {
+		log.WithErr(err).Alert("Failed to seed database: %v", err)
+	}
+	log.Info("Successfully seeded database")
 }
 
 func main() {
@@ -54,6 +68,7 @@ func main() {
 	}
 
 	runMigrations()
+	runSeeds()
 
 	// run
 	server.Run()


### PR DESCRIPTION
Initial Seed Script

**Why**
We want the ability to seed specific tables with data as the database boots up. This will allow us to easily populate tables with values.

**How**
Create a seeder interface and seed file for each table we wish to seed. Add runSeed function to main that will add all seed functions and run them. Update migrations to handle the ability to remove certain columns if they exist. Clean up penaltyType table.