### PR TITLE
Fixed Get Logo By ID endpoint to return the image

### DIFF
--- a/backend/internal/server/apis/sports/components/logo.go
+++ b/backend/internal/server/apis/sports/components/logo.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	apis.RegisterHandler(fiber.MethodPost, "/logos", auth.Public, handleLogoUpload)
 	apis.RegisterHandler(fiber.MethodGet, "/logos/:id<int>", auth.Public, handleGetLogoByID)
+	// Need to be able to specify Type in the RegisterHandler
 }
 
 func handleLogoUpload(c *fiber.Ctx) error {
@@ -57,6 +58,6 @@ func handleGetLogoByID(c *fiber.Ctx) error {
 		return responder.InternalServerError(c)
 	}
 
-	// Send JSON response
-	return responder.OkWithData(c, logo)
+	c.Type("png")
+	return c.Send(logo.Image)
 }

--- a/backend/internal/server/apis/sports/components/logo.go
+++ b/backend/internal/server/apis/sports/components/logo.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	apis.RegisterHandler(fiber.MethodPost, "/logos", auth.Public, handleLogoUpload)
 	apis.RegisterHandler(fiber.MethodGet, "/logos/:id<int>", auth.Public, handleGetLogoByID)
-	// Need to be able to specify Type in the RegisterHandler
+	// Need to be able to specify ctx.Type (the request's Content-Type) in the RegisterHandler
 }
 
 func handleLogoUpload(c *fiber.Ctx) error {

--- a/static/oas/v1/sports/components/games.yml
+++ b/static/oas/v1/sports/components/games.yml
@@ -44,7 +44,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            type: integer
       responses:
         200:
           description: The response body should contain the game details
@@ -63,7 +63,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            type: integer
       description: Update game details by ID
       requestBody:
         required: true

--- a/static/oas/v1/sports/components/logos.yml
+++ b/static/oas/v1/sports/components/logos.yml
@@ -39,16 +39,12 @@ paths:
             type: integer
       responses:
         200:
-          description: The response body should contain the png logo
+          description: OK
           content:
-            multipart/form-data:
+            image/png:
               schema:
-                type: object
-                properties:
-                  image:
-                    type: string
-                    contentMediaType: image/png
-                    format: binary
+                type: string
+                format: binary
         400:
           $ref: "../../common/errors.yml#/components/responses/BadRequest"
 

--- a/static/oas/v1/sports/components/logos.yml
+++ b/static/oas/v1/sports/components/logos.yml
@@ -17,11 +17,11 @@ paths:
                   format: binary
       responses:
         200:
-          description: Successfully uploaded a team's logo
+          description: OK
           content:
             application/json:
               schema:
-        $ref: '#/components/schemas/PostLogoResponse'
+                $ref: '#/components/schemas/PostLogoResponse'
         400:
           $ref: "../../common/errors.yml#/components/responses/BadRequest"
   /logos/{id}:

--- a/static/oas/v1/sports/components/logos.yml
+++ b/static/oas/v1/sports/components/logos.yml
@@ -4,7 +4,7 @@ paths:
       tags:
         - Logos
       summary: Create Team Logo
-      description: Uploads a team's logo
+      description: Uploads a team's logo. This currently supports png files only.
       requestBody:
         content:
           multipart/form-data:
@@ -13,6 +13,7 @@ paths:
               properties:
                 image:
                   type: string
+                  contentMediaType: image/png
                   format: binary
       responses:
         200:
@@ -35,10 +36,10 @@ paths:
           required: true
           description: The ID of the logo to retrieve
           schema:
-            type: string
+            type: integer
       responses:
         200:
-          description: The response body should contain the logo binary
+          description: The response body should contain the png logo
           content:
             multipart/form-data:
               schema:
@@ -46,6 +47,7 @@ paths:
                 properties:
                   image:
                     type: string
+                    contentMediaType: image/png
                     format: binary
         400:
           $ref: "../../common/errors.yml#/components/responses/BadRequest"

--- a/static/oas/v1/sports/components/teams.yml
+++ b/static/oas/v1/sports/components/teams.yml
@@ -47,7 +47,7 @@ paths:
           required: true
           description: The ID of the team to retrieve
           schema:
-            type: string
+            type: integer
       responses:
         200:
           description: The response body should contain the list of teams
@@ -68,7 +68,7 @@ paths:
           required: true
           description: The ID of the team to update
           schema:
-            type: string
+            type: integer
       requestBody:
         description: A JSON object with a valid team
         required: true


### PR DESCRIPTION
Changes
- Fixed Get Logo By ID endpoint to return the image
- Updated Open API spec ID's to integers instead of strings

Limitations:
- Logos API only currently supports png files, though that is not enforced

Future plan:
- Adjust Logo model to include a filename (logo.png) or fileType (png) field. Storing this in the database record will allow us to determine the Content-Type in the Get endpoint's response