### PR TITLE
Standardize Models

### DIFF
--- a/backend/internal/db/league.go
+++ b/backend/internal/db/league.go
@@ -3,7 +3,7 @@ package db
 import "github.com/jak103/powerplay/internal/models"
 
 // GetLeagues todo: investigate: Struct session has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation.
-func (s *session) GetLeagues(sortField, sortOrder string) ([]models.League, error) {
+func (s session) GetLeagues(sortField, sortOrder string) ([]models.LeagueRecord, error) {
 	if sortField == "" {
 		sortField = "ID"
 	}
@@ -11,24 +11,24 @@ func (s *session) GetLeagues(sortField, sortOrder string) ([]models.League, erro
 		sortOrder = "ASC"
 	}
 
-	leagues := make([]models.League, 0)
+	leagues := make([]models.LeagueRecord, 0)
 	err := s.connection.Order(sortField + " " + sortOrder).Find(&leagues)
 	return resultsOrError(leagues, err)
 }
 
-func (s session) GetLeaguesPaginated(offset, limit int, sortField, sortOrder string) ([]models.League, error) {
+func (s session) GetLeaguesPaginated(offset, limit int, sortField, sortOrder string) ([]models.LeagueRecord, error) {
 	if sortField == "" {
 		sortField = "ID"
 	}
 	if sortOrder == "" {
 		sortOrder = "asc"
 	}
-	leagues := make([]models.League, 0)
-	err := s.connection.Offset(offset).Limit(limit).Order(sortField + " " + sortOrder).Find(&leagues)
+	leagues := make([]models.LeagueRecord, 0)
+	err := s.connection.Preload("Teams").Offset(offset).Limit(limit).Order(sortField + " " + sortOrder).Find(&leagues)
 	return resultsOrError(leagues, err)
 }
 
-func (s session) CreateLeague(request *models.League) error {
+func (s session) CreateLeague(request *models.LeagueRecord) error {
 	result := s.connection.Create(request)
 	return result.Error
 }

--- a/backend/internal/db/migrations/migrate.go
+++ b/backend/internal/db/migrations/migrate.go
@@ -99,7 +99,7 @@ func Run(db *gorm.DB) error {
 		err := tx.AutoMigrate(
 			&models.User{},
 			&models.Season{},
-			&models.League{},
+			&models.LeagueRecord{},
 			&models.Team{},
 			&models.Roster{},
 			&models.Venue{},

--- a/backend/internal/db/seeders/fake_data/leagues.go
+++ b/backend/internal/db/seeders/fake_data/leagues.go
@@ -21,18 +21,18 @@ func (s LeagueSeeder) Seed(db *gorm.DB, args ...interface{}) (interface{}, error
 	}
 
 	existingNames := make(map[string]bool)
-	var createdLeagues []models.League
+	var createdLeagues []models.LeagueRecord
 	for i := 0; i < 4; i++ {
-		league := models.League{
-			Name:          unittesting.GenerateUniqueName(existingNames),
-			CorrelationId: faker.UUIDHyphenated(),
-			SeasonID:      seasonID,
-			Teams:         []models.Team{},
+		league := models.LeagueRecord{
+			Name:     unittesting.GenerateUniqueName(existingNames),
+			LeagueID: faker.UUIDHyphenated(),
+			SeasonID: seasonID,
+			Teams:    []models.Team{},
 		}
-		if err := db.FirstOrCreate(&league, models.League{
-			Name:          league.Name,
-			CorrelationId: league.CorrelationId,
-			SeasonID:      league.SeasonID,
+		if err := db.FirstOrCreate(&league, models.LeagueRecord{
+			Name:     league.Name,
+			LeagueID: league.LeagueID,
+			SeasonID: league.SeasonID,
 		}).Error; err != nil {
 			return nil, err
 		}

--- a/backend/internal/db/seeders/fake_data/season.go
+++ b/backend/internal/db/seeders/fake_data/season.go
@@ -17,7 +17,7 @@ func (s SeasonSeeder) Seed(db *gorm.DB, args ...interface{}) (interface{}, error
 		End:           time.Now().AddDate(0, 3, 0),
 		Registrations: []models.Registration{},
 		Schedule:      []models.Game{},
-		Leagues:       []models.League{},
+		LeagueRecords: []models.LeagueRecord{},
 	}
 	if err := db.FirstOrCreate(&season, season).Error; err != nil {
 		return nil, err

--- a/backend/internal/db/seeders/fake_data/teams.go
+++ b/backend/internal/db/seeders/fake_data/teams.go
@@ -13,31 +13,31 @@ type TeamSeeder struct{}
 
 func (s TeamSeeder) Seed(db *gorm.DB, args ...interface{}) (interface{}, error) {
 	fake := fakercolor.New()
-	// Expecting the first argument to be the LeagueID
+	// Expecting the first argument to be the LeagueRecordID
 	if len(args) < 1 {
 		return nil, errors.New("missing required arguments")
 	}
 	leagueID, ok := args[0].(uint)
 	if !ok {
-		return nil, errors.New("invalid type for LeagueID")
+		return nil, errors.New("invalid type for LeagueRecordID")
 	}
 
 	existingNames := make(map[string]bool)
 	var createdTeams []models.Team
 	for i := 0; i < 4; i++ {
 		team := models.Team{
-			CorrelationId: faker.UUIDHyphenated(),
-			Name:          unittesting.GenerateUniqueName(existingNames),
-			Color:         fake.Color().Hex(),
-			LeagueID:      leagueID,
-			Wins:          0,
-			Losses:        0,
+			CorrelationId:  faker.UUIDHyphenated(),
+			Name:           unittesting.GenerateUniqueName(existingNames),
+			Color:          fake.Color().Hex(),
+			LeagueRecordID: leagueID,
+			Wins:           0,
+			Losses:         0,
 		}
 		if err := db.FirstOrCreate(&team, models.Team{
-			CorrelationId: team.CorrelationId,
-			Name:          team.Name,
-			Color:         team.Color,
-			LeagueID:      team.LeagueID,
+			CorrelationId:  team.CorrelationId,
+			Name:           team.Name,
+			Color:          team.Color,
+			LeagueRecordID: team.LeagueRecordID,
 		}).Error; err != nil {
 			return nil, err
 		}

--- a/backend/internal/models/league.go
+++ b/backend/internal/models/league.go
@@ -1,9 +1,9 @@
 package models
 
-type League struct {
+type LeagueRecord struct {
 	DbModel
-	CorrelationId string `json:"correlation_id"`
-	SeasonID      uint   `json:"season_id"`
-	Name          string `json:"name"`
-	Teams         []Team `json:"teams"`
+	LeagueID string `json:"league_id"`
+	SeasonID uint   `json:"season_id"`
+	Name     string `json:"name"`
+	Teams    []Team `json:"teams"`
 }

--- a/backend/internal/models/season.go
+++ b/backend/internal/models/season.go
@@ -9,5 +9,5 @@ type Season struct {
 	End           time.Time      `json:"end"`
 	Registrations []Registration `json:"registrations"`
 	Schedule      []Game         `json:"schedule"`
-	Leagues       []League       `json:"leagues"`
+	LeagueRecords []LeagueRecord `json:"league_records"`
 }

--- a/backend/internal/models/team.go
+++ b/backend/internal/models/team.go
@@ -2,14 +2,14 @@ package models
 
 type Team struct {
 	DbModel
-	CorrelationId string  `json:"correlation_id"`
-	Name          string  `json:"name"`
-	LogoId        string  `json:"logo_id"`
-	Color         string  `json:"color"`
-	LeagueID      uint    `json:"league_id"`
-	League        League  `json:"league"`
-	Roster        *Roster `json:"roster"`
-	RosterID      *uint   `json:"roster_id"`
+	CorrelationId  string       `json:"correlation_id"`
+	Name           string       `json:"name"`
+	LogoId         string       `json:"logo_id"`
+	Color          string       `json:"color"`
+	LeagueRecordID uint         `json:"league_record_id"`
+	LeagueRecord   LeagueRecord `json:"league_record"`
+	Roster         *Roster      `json:"roster"`
+	RosterID       *uint        `json:"roster_id"`
 
 	Wins   int `json:"wins"`
 	Losses int `json:"losses"`

--- a/backend/internal/server/apis/sports/components/league.go
+++ b/backend/internal/server/apis/sports/components/league.go
@@ -23,7 +23,7 @@ func getLeaguesHandler(c *fiber.Ctx) error {
 		return responder.BadRequest(c, err.Error())
 	}
 
-	sortField, sortOrder, err := query_params.GetSortParams(c, reflect.TypeOf(models.League{}))
+	sortField, sortOrder, err := query_params.GetSortParams(c, reflect.TypeOf(models.LeagueRecord{}))
 	if err != nil {
 		return responder.BadRequest(c, err.Error())
 	}
@@ -53,7 +53,7 @@ func getLeaguesHandler(c *fiber.Ctx) error {
 func postLeagueHandler(c *fiber.Ctx) error {
 	log := locals.Logger(c)
 
-	leagueRequest := &models.League{}
+	leagueRequest := &models.LeagueRecord{}
 	err := c.BodyParser(leagueRequest)
 	if err != nil {
 		log.WithErr(err).Alert("Failed to parse leagues request payload")

--- a/backend/main.go
+++ b/backend/main.go
@@ -49,22 +49,22 @@ func runFakeDataSeeds() {
 	}
 	log.Info("Successfully seeded Season")
 
-	// Seed League with SeasonID
+	// Seed LeagueRecord with SeasonID
 	leagues, err := leagueSeeder.Seed(db.GetDB(), season.(models.Season).ID)
 	if err != nil {
-		log.WithErr(err).Alert("Failed to seed League: %v", err)
+		log.WithErr(err).Alert("Failed to seed LeagueRecord: %v", err)
 		return
 	}
-	log.Info("Successfully seeded League")
+	log.Info("Successfully seeded LeagueRecord")
 
-	// Seed Teams for each League
-	for _, league := range leagues.([]models.League) {
+	// Seed Teams for each LeagueRecord
+	for _, league := range leagues.([]models.LeagueRecord) {
 		_, err = teamSeeder.Seed(db.GetDB(), league.ID)
 		if err != nil {
-			log.WithErr(err).Alert("Failed to seed Teams for League %d: %v", league.ID, err)
+			log.WithErr(err).Alert("Failed to seed Teams for LeagueRecord %d: %v", league.ID, err)
 			return
 		}
-		log.Info("Successfully seeded Teams for League %d", league.ID)
+		log.Info("Successfully seeded Teams for LeagueRecord %d", league.ID)
 	}
 
 	// Seed Venues


### PR DESCRIPTION
Standardize Models

**Why**
We want to standardize the models to better reflect what they actually are. The main aim is to rename League -> LeagueRecord as it is an instance of a League to a specific season. The pattern would follow for Teams if we decide to go this route.

**How**
Rename League -> LeagueRecord. Rename CorrelationId -> LeagueID.